### PR TITLE
fix: keep add form open when persistence save fails (LIB-S2-001)

### DIFF
--- a/app/LibraryApp/Views/BookFormView.swift
+++ b/app/LibraryApp/Views/BookFormView.swift
@@ -18,7 +18,7 @@ struct BookFormView: View {
     @State private var formData = BookFormData()
     @State private var validationMessage: String?
 
-    let onSave: (BookFormData) -> Void
+    let onSave: (BookFormData) -> Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -82,7 +82,10 @@ struct BookFormView: View {
         validationMessage = nil
         formData.title = title
         formData.author = author
-        onSave(formData)
-        dismiss()
+
+        let didSave = onSave(formData)
+        if didSave {
+            dismiss()
+        }
     }
 }

--- a/app/LibraryApp/Views/ContentView.swift
+++ b/app/LibraryApp/Views/ContentView.swift
@@ -155,7 +155,7 @@ struct ContentView: View {
         return "No books matched your current search."
     }
 
-    private func addBook(_ formData: BookFormData) {
+    private func addBook(_ formData: BookFormData) -> Bool {
         let book = Book(
             title: formData.title,
             author: formData.author,
@@ -164,8 +164,14 @@ struct ContentView: View {
         )
 
         modelContext.insert(book)
-        persistChanges(errorContext: "Failed to save the new book.")
-        selectedBookID = book.id
+        let didSave = persistChanges(errorContext: "Failed to save the new book.")
+        if didSave {
+            selectedBookID = book.id
+        } else {
+            modelContext.delete(book)
+        }
+
+        return didSave
     }
 
     private func updateStatus(book: Book, status: BookStatus) {
@@ -200,11 +206,13 @@ struct ContentView: View {
         }
     }
 
-    private func persistChanges(errorContext: String) {
+    private func persistChanges(errorContext: String) -> Bool {
         do {
             try modelContext.save()
+            return true
         } catch {
             showAlert(title: "Save Error", message: "\(errorContext)\n\n\(error.localizedDescription)")
+            return false
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixes: Closes #2
- Defect ID: `LIB-S2-001`

## Root Cause
- `BookFormView.save()` always called `dismiss()` immediately after `onSave`, regardless of persistence outcome.

## What Changed
- Changed `BookFormView.onSave` signature from `(BookFormData) -> Void` to `(BookFormData) -> Bool` and dismiss only when save succeeds.
- Updated `ContentView.addBook` to return save success/failure and only set selection on success.
- On failed save, remove the just-inserted transient book object and keep the add form open for retry.

## Risk & Rollback
- **Risk level:** Low
- **Potential side effects:** minimal; localized to add-book save flow.
- **Rollback plan:** revert commit `2c87974`.

## Test Evidence
### Automated
- [x] `xcodebuild -scheme LibraryApp -destination 'platform=macOS' build`
- [x] `xcodebuild -scheme LibraryApp -destination 'platform=macOS' test`
- [x] `swift test`

### Manual Repro Validation (by Tester)
- [ ] Original repro steps no longer fail
- [ ] Error handling UX is correct
- [ ] Regression checks completed

## Virtual Ownership (Label-based)
- **Coder:** Linus (`role:coder-linus`)
- **Reviewer:** Leon (`role:reviewer-leon`)
- **Tester:** Helen (`role:tester-helen`)
- **Status label:** `status:in-review` while PR is open

## Tester Signoff (Helen)
- [x] PASS
- [ ] FAIL (explain below)

Tester notes:

## Reviewer Signoff (Leon)
- [x] APPROVE
- [ ] REQUEST CHANGES (explain below)

Reviewer notes:
