### PR TITLE
fix: replace invalid find command placement

### DIFF
--- a/app/LibraryApp/LibraryAppApp.swift
+++ b/app/LibraryApp/LibraryAppApp.swift
@@ -19,7 +19,7 @@ struct LibraryAppApp: App {
                 .keyboardShortcut("n", modifiers: .command)
             }
 
-            CommandGroup(replacing: .find) {
+            CommandMenu("Search") {
                 Button("Focus Search") {
                     commandCenter.triggerFocusSearch()
                 }

--- a/app/LibraryAppTests/UICommandCenterTests.swift
+++ b/app/LibraryAppTests/UICommandCenterTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import LibraryApp
+
+final class UICommandCenterTests: XCTestCase {
+    func testTriggerNewBookIncrementsSignal() {
+        let commandCenter = UICommandCenter()
+        XCTAssertEqual(commandCenter.newBookSignal, 0)
+
+        commandCenter.triggerNewBook()
+        XCTAssertEqual(commandCenter.newBookSignal, 1)
+
+        commandCenter.triggerNewBook()
+        XCTAssertEqual(commandCenter.newBookSignal, 2)
+    }
+
+    func testTriggerFocusSearchIncrementsSignal() {
+        let commandCenter = UICommandCenter()
+        XCTAssertEqual(commandCenter.focusSearchSignal, 0)
+
+        commandCenter.triggerFocusSearch()
+        XCTAssertEqual(commandCenter.focusSearchSignal, 1)
+
+        commandCenter.triggerFocusSearch()
+        XCTAssertEqual(commandCenter.focusSearchSignal, 2)
+    }
+}


### PR DESCRIPTION
Fixes #10

## Summary
- replace invalid `CommandGroup(replacing: .find)` with `CommandMenu("Search")`
- keep Cmd+F mapped to Focus Search action
- add regression tests for command center trigger signals

## Validation
- swift test (8 passed, 0 failed)