### PR TITLE
fix: return keyboard focus to app search on Cmd+F (#12)

### DIFF
--- a/app/LibraryApp/Views/ContentView.swift
+++ b/app/LibraryApp/Views/ContentView.swift
@@ -112,8 +112,15 @@ struct ContentView: View {
             Text(alertMessage)
         }
         .onAppear {
+            activateAppWindow()
+
             if selectedBookID == nil {
                 selectedBookID = filteredBooks.first?.id
+            }
+
+            // If Cmd+F fired during startup before observers were attached, apply focus now.
+            if commandCenter.focusSearchSignal > 0 {
+                focusSearchField()
             }
         }
         .onChange(of: filteredBooks.map(\.id)) { ids in
@@ -243,10 +250,19 @@ struct ContentView: View {
     }
 
     private func focusSearchField() {
+        // Ensure keyboard focus leaves the launching terminal and returns to the app window.
+        activateAppWindow()
+
         // Re-assert focus on the next runloop so menu-command invocation reliably moves focus.
         searchIsFocused = false
         Task { @MainActor in
+            activateAppWindow()
             searchIsFocused = true
         }
+    }
+
+    private func activateAppWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        (NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first)?.makeKeyAndOrderFront(nil)
     }
 }


### PR DESCRIPTION
Fixes #12

## Summary
- activate app window on appear and before/inside focus handoff
- re-apply search focus when command signal already fired at startup
- keep scope limited to search focus reliability

## Validation
- HOME=/tmp swift test --disable-sandbox (8 passed)